### PR TITLE
fix(packages): use right name in question

### DIFF
--- a/packages/zsh-syntax-highlighting.sh
+++ b/packages/zsh-syntax-highlighting.sh
@@ -2,7 +2,7 @@
 
 function zsh-syntax-highlighting::install() {
   # Ask if want install skip if respond no
-  question "Do you want install zsh-autosuggestions ?" y || return
+  question "Do you want install zsh-syntax-highlighting ?" y || return
 
   [ ! -n "$ZSH_CUSTOM" ] && { echo "ZSH_CUSTOM is not set"; exit 1; }
 


### PR DESCRIPTION
Hello,
This PR fix question for `zsh-syntax-highlighting` package.